### PR TITLE
Fix stickerSet.save crash on queued video sticker uploads

### DIFF
--- a/utils/add-sticker.js
+++ b/utils/add-sticker.js
@@ -91,7 +91,21 @@ convertQueue.on('global:completed', async (jobId, result) => {
     source: Buffer.from(content, 'base64')
   }
 
-  const uploadResult = await uploadSticker(input.userId, input.stickerSet, input.stickerFile, stickerExtra)
+  // input.stickerSet is a plain object here — Bull serialized the job to JSON
+  // in Redis, so it lost its Mongoose document methods (e.g. .save()) that
+  // uploadSticker relies on. Re-fetch the live document before calling it.
+  const stickerSet = await db.StickerSet.findById(input.stickerSet._id)
+
+  if (!stickerSet) {
+    if (input?.botId === botInfo?.id) {
+      await telegram.sendMessage(input.chatId, i18n.t(input.locale || 'en', 'sticker.add.error.convert'), {
+        parse_mode: 'HTML'
+      }).catch(() => {})
+    }
+    return
+  }
+
+  const uploadResult = await uploadSticker(input.userId, stickerSet, input.stickerFile, stickerExtra)
 
   if (input.convertingMessageId) await telegram.deleteMessage(input.chatId, input.convertingMessageId).catch(() => {})
 


### PR DESCRIPTION
Bull serializes job data to JSON in Redis, so the stickerSet passed
into the video convertQueue job loses its Mongoose document methods
by the time global:completed fires. Re-fetch the live document before
calling uploadSticker so .save() (used by placeholder cleanup and
first-sticker set creation) works again.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017RCxJ3UQ9vk3QyHemjBRh7